### PR TITLE
:fire: Replace BidirectionalIteratorScrewdriver with RuneIteratorScre…

### DIFF
--- a/lib/collection/iterator.dart
+++ b/lib/collection/iterator.dart
@@ -40,8 +40,9 @@ extension IteratorScrewdriver<E> on Iterator<E> {
   E? next() => moveNext() ? current : null;
 }
 
-/// provides extensions for [BidirectionalIterator]
-extension BidirectionalIteratorScrewdriver<E> on BidirectionalIterator<E> {
+/// provides extensions for [RuneIterator]
+@Deprecated('Use IteratorScrewdriver instead')
+extension RuneIteratorScrewdriver on RuneIterator {
   /// moves the current index backwards and returns current element
-  E? previous() => movePrevious() ? current : null;
+  int? previous() => movePrevious() ? current : null;
 }


### PR DESCRIPTION
Since `BidirectionalIterator` is deprecated in dart, this replaces its extension `BidirectionalIteratorScrewdriver` with `RuneIteratorScrewdriver`.